### PR TITLE
Fix spelling of react-static on about page

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -21,7 +21,7 @@ export default () => (
             className="block news-button"
             href="https://github.com/react-static/react-static"
           >
-            reac-static
+            react-static
           </a>
           <a
             className="block news-button"


### PR DESCRIPTION
It's now `react-static` instead of `reac-static`.